### PR TITLE
Version-independent task setup?

### DIFF
--- a/R/taskscheduleR.R
+++ b/R/taskscheduleR.R
@@ -116,6 +116,10 @@ taskscheduler_create <- function(taskname = basename(rscript),
                                  rscript_args = "",
                                  schtasks_extra = "",
                                  debug = FALSE){
+  if (grepl("\\\\R\\\\R-", Sys.getenv("PATH"))) {
+    Rexe <- "Rscript"
+  }
+  
   if(!file.exists(rscript)){
     stop(sprintf("File %s does not exist", rscript))
   }


### PR DESCRIPTION
Hi, 

Thank you for setting up a great package. I noticed recently as I was updating my R from a version 3.5.1 to 3.6.0 that the tasks previously set all started to fail, because `taskscheduler_create` used `Sys.getenv("R_HOME")` which would contain version numbers, such as 

    C:/PROGRA~1/R/R-35~1.1

So when there was a new R and new path of `C:/PROGRA~1/R/R-36~1.0`, it no longer worked.

If R is included in the path, the `Rexe` argument can simply be substituted as `"Rscript"` and the task will run just fine. I wrote an if-statement that checks for R in path and then replacing `Rexe`. I am unsure how to undo the path-shortening for `Sys.getenv("R_HOME")` (apparently a DOS 8.3 naming convention?) so the `grepl` part is a little hacky. 

I've only tested it on my machine/task, but let me know what you think. 
