### PR TITLE
Update taskschedulerAddin.R

### DIFF
--- a/R/taskschedulerAddin.R
+++ b/R/taskschedulerAddin.R
@@ -199,7 +199,7 @@ taskschedulerAddin <- function(RscriptRepository,
     ###########################
     shiny::observeEvent(input$Stop, {
       shiny::updateSelectInput(session, inputId="getFiles", choices = list.files(RscriptRepository, pattern = ".R$|.r$"))
-      taskcheduler_stop(taskname = input$getFiles)
+      taskscheduler_stop(taskname = input$getFiles)
     })
     
     ###########################


### PR DESCRIPTION
Changed taskcheduler_stop to taskscheduler_stop to prevent warning message when using taskschedulerAddin()

![image](https://github.com/bnosac/taskscheduleR/assets/2274317/76f6a33f-9eed-4d82-981e-9df192698880)
