### PR TITLE
stop task creation if task is too long or if debug is TRUE - introduces breaking changes

### DIFF
--- a/R/taskscheduleR.R
+++ b/R/taskscheduleR.R
@@ -37,6 +37,7 @@ taskscheduler_ls <- function(encoding = 'UTF-8', ...){
 #' More information about the scheduling format can be found in the docs/schtasks.pdf file inside this package.
 #' The rscript file will be scheduled with Rscript.exe and the log of the run will be put in the .log file which can be found in the same directory
 #' as the location of the rscript
+#' Be mindful of your rscript path length and any additional rscriptargs or options. The total length of the Windows TR must be less than 260 characters, and about 80 characters are already used to point to the RScript.exe. Your log file path will be about the same length as your rscript. 260 - 80, leaves about 180 characters total, so approximately 90 characters max for rscript path with no rscriptargs or options. These numbers are given as example only as each system is a little different.
 #' 
 #' @param taskname a character string with the name of the task. Defaults to the filename. Should not contain any spaces.
 #' @param rscript the full path to the .R script with the R code to execute. Should not contain any spaces.
@@ -57,7 +58,7 @@ taskscheduler_ls <- function(encoding = 'UTF-8', ...){
 #' @param rscript_args character string with further arguments passed on to Rscript. See args in \code{\link{Rscript}}.
 #' @param rscript_options character string with further options passed on to Rscript. See options in \code{\link{Rscript}}.
 #' @param schtasks_extra character string with further schtasks arguments. See the inst/docs/schtasks.pdf 
-#' @param debug logical to print the system call to screen
+#' @param debug logical to print the system call to screen. if TRUE, schedule is not actually passed. Defaults to FALSE.
 #' @param exec_path character string of the path where cmd should be executed. Defaults to system path. 
 #' @return the system call to schtasks /Create 
 #' @export
@@ -165,7 +166,7 @@ taskscheduler_create <- function(taskname = basename(rscript),
     
   }
 
-    if(nchar(task) > 260){
+    if(nchar(task) > 260){ 
     warning(sprintf("Passing on this to the TR argument of schtasks.exe: %s, this is too long. Consider putting your scripts into another folder", task))
   }
   cmd <- sprintf('schtasks /Create /TN %s /TR %s /SC %s', 
@@ -197,8 +198,8 @@ taskscheduler_create <- function(taskname = basename(rscript),
     cmd <- sprintf("%s /M %s", cmd, months)
   }
   cmd <- sprintf("%s %s", cmd, schtasks_extra)
-  if(debug){
-    message(sprintf("Creating task schedule: %s", cmd))  
+  if(debug){ # if debug, do not actually run
+    return(message(sprintf("Creating task schedule: %s", cmd)))  
   }
   system(cmd, intern = TRUE)
 }

--- a/R/taskscheduleR.R
+++ b/R/taskscheduleR.R
@@ -168,6 +168,7 @@ taskscheduler_create <- function(taskname = basename(rscript),
 
     if(nchar(task) > 260){ 
     warning(sprintf("Passing on this to the TR argument of schtasks.exe: %s, this is too long. Consider putting your scripts into another folder", task))
+      stopifnot("Will Fail, try a shorter path", nchar(task) <= 260)
   }
   cmd <- sprintf('schtasks /Create /TN %s /TR %s /SC %s', 
                  shQuote(taskname, type = "cmd"), 

--- a/man/taskscheduler_create.Rd
+++ b/man/taskscheduler_create.Rd
@@ -57,7 +57,7 @@ running a scheduled ONIDLE task. The valid range is 1 - 999 minutes.}
 
 \item{schtasks_extra}{character string with further schtasks arguments. See the inst/docs/schtasks.pdf}
 
-\item{debug}{logical to print the system call to screen}
+\item{debug}{logical to print the system call to screen. if TRUE, schedule is not actually passed. Defaults to FALSE.}
 
 \item{exec_path}{character string of the path where cmd should be executed. Defaults to system path.}
 }
@@ -69,6 +69,7 @@ Schedule an R script with the Windows task scheduler. E.g. daily, weekly, once, 
 More information about the scheduling format can be found in the docs/schtasks.pdf file inside this package.
 The rscript file will be scheduled with Rscript.exe and the log of the run will be put in the .log file which can be found in the same directory
 as the location of the rscript
+Be mindful of your rscript path length and any additional rscriptargs or options. The total length of the Windows TR must be less than 260 characters, and about 80 characters are already used to point to the RScript.exe. Your log file path will be about the same length as your rscript. 260 - 80, leaves about 180 characters total, so approximately 90 characters max for rscript path with no rscriptargs or options. These numbers are given as example only as each system is a little different.
 }
 \examples{
 myscript <- system.file("extdata", "helloworld.R", package = "taskscheduleR")


### PR DESCRIPTION
This PR expands documentation but more drastically changes behavior of taskscheduler_create:
- will stop with error if `nchar(task) > 260`
- will not attempt to actually schedule the task if debug = TRUE

Both of these changes were inspired by #106 

However, they are breaking changes. Users in the habit of running with `debug = TRUE` to simply 'see the call' might expect it to still run. Not sure if this is desired.

Also, I could not replicate the behavior identified in #106. Using an `rscript` of length 102 and 115, I do not see the task being clipped. However, The user did say that the debug print value is not what is actually passed to the TR in the Windows task scheduler. I am on a Mac, so it would be good to see this actually happening. The code that warns the user about long file names has been in place (based on blame) for years, so the OG poster should have been warned. 


Here is an example. I'm running it after my edits, so you see an error about it failing because of TR length which is not in the original package (current behavior is just a warning)

``` r
devtools::load_all()
#> ℹ Loading taskscheduleR
```

``` r
# a very long rscript path
myscript <- path.expand("~/this_is_a_long_fake_folder_name/this_is_a_nested_fake_folder/long_folder_eesh/script_with_a_long_name.R")
nchar(myscript)
#> [1] 115
```

``` r
taskscheduler_create(taskname = "myfancyscript_sun", 
                     rscript = myscript, 
                     schedule = "WEEKLY", 
                     starttime = "09:10", 
                     days = 'SUN',
                     debug = TRUE)
#> Warning in taskscheduler_create(taskname = "myfancyscript_sun", rscript =
#> myscript, : Passing on this to the TR argument of schtasks.exe: cmd /c
#> /Library/Frameworks/R.framework/Resources/bin/Rscript.exe
#> '/Users/jess/this_is_a_long_fake_folder_name/this_is_a_nested_fake_folder/long_folder_eesh/script_with_a_long_name.R'
#> >>
#> '/Users/jess/this_is_a_long_fake_folder_name/this_is_a_nested_fake_folder/long_folder_eesh/script_with_a_long_name.log'
#> 2>&1, this is too long. Consider putting your scripts into another folder
#> Error in taskscheduler_create(taskname = "myfancyscript_sun", rscript = myscript, : "Will Fail, try a shorter path" is not TRUE
```

``` r

# rscript path that is between 100 and 103 
myscript <- path.expand("~/this_is_a_long_fake_folder_name/this_is_a_nested_fake_folder/long_folder_eesh/scriptname.R")
nchar(myscript)
#> [1] 102
```

``` r
taskscheduler_create(taskname = "myfancyscript_sun", 
                     rscript = myscript, 
                     schedule = "WEEKLY", 
                     starttime = "09:10", 
                     days = 'SUN',
                     debug = TRUE)
#> Warning in taskscheduler_create(taskname = "myfancyscript_sun", rscript =
#> myscript, : Passing on this to the TR argument of schtasks.exe: cmd /c
#> /Library/Frameworks/R.framework/Resources/bin/Rscript.exe
#> '/Users/jess/this_is_a_long_fake_folder_name/this_is_a_nested_fake_folder/long_folder_eesh/scriptname.R'
#> >>
#> '/Users/jess/this_is_a_long_fake_folder_name/this_is_a_nested_fake_folder/long_folder_eesh/scriptname.log'
#> 2>&1, this is too long. Consider putting your scripts into another folder
#> Error in taskscheduler_create(taskname = "myfancyscript_sun", rscript = myscript, : "Will Fail, try a shorter path" is not TRUE
```

``` r

# and a short rscript path
myscript <- path.expand("~/this_is_a_long_fake_folder_name/scriptname.R")
nchar(myscript)
#> [1] 56
```

``` r
taskscheduler_create(taskname = "myfancyscript_sun", 
                     rscript = myscript, 
                     schedule = "WEEKLY", 
                     starttime = "09:10", 
                     days = 'SUN',
                     debug = TRUE)
#> Creating task schedule: schtasks /Create /TN "myfancyscript_sun" /TR "cmd /c /Library/Frameworks/R.framework/Resources/bin/Rscript.exe  '/Users/jess/this_is_a_long_fake_folder_name/scriptname.R'  >> '/Users/jess/this_is_a_long_fake_folder_name/scriptname.log' 2>&1" /SC WEEKLY /ST 09:10 /SD '18/04/2025' /D SUN
```

<sup>Created on 2025-04-18 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

